### PR TITLE
Change the structure of FunPayParser, add copyright

### DIFF
--- a/.idea/copyright/Apache_License.xml
+++ b/.idea/copyright/Apache_License.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    <option name="myName" value="Apache License" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <settings default="Apache License">
+    <module2copyright>
+      <element module="Project Files" copyright="Apache License" />
+    </module2copyright>
+  </settings>
+</component>

--- a/core/src/main/java/ru/funpay4j/client/FunPayParser.java
+++ b/core/src/main/java/ru/funpay4j/client/FunPayParser.java
@@ -1,9 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.client;
 
-import ru.funpay4j.core.commands.offer.GetOffer;
-import ru.funpay4j.core.commands.game.GetPromoGames;
-import ru.funpay4j.core.commands.lot.GetLot;
-import ru.funpay4j.core.commands.user.GetUser;
 import ru.funpay4j.core.objects.game.PromoGame;
 import ru.funpay4j.core.objects.lot.Lot;
 import ru.funpay4j.core.objects.offer.Offer;
@@ -11,14 +21,43 @@ import ru.funpay4j.core.objects.user.User;
 
 import java.util.List;
 
+/**
+ * Interface for parsing data from FunPay
+ * Defines the methods that any FunPay parser implementation must provide
+ *
+ * @author panic08
+ * @since 1.0.0
+ */
 public interface FunPayParser {
+    /**
+     * Parse lot by lot id
+     *
+     * @param lotId lotId by which Lot will be parsed
+     * @return lot
+     */
+    Lot parseLot(long lotId);
 
-    //Specific parsing requests
-    Lot parse(GetLot command);
+    /**
+     * Parse promoGames by query
+     *
+     * @param query query by which PromoGames will be parsed
+     * @return promoGames
+     */
+    List<PromoGame> parsePromoGames(String query);
 
-    List<PromoGame> parse(GetPromoGames command);
+    /**
+     * Parse offer by offer id
+     *
+     * @param offerId offerId by which Offer will be parsed
+     * @return offer
+     */
+    Offer parseOffer(long offerId);
 
-    Offer parse(GetOffer command);
-
-    User parse(GetUser command);
+    /**
+     * Parse user by user id
+     *
+     * @param userId userId by which User will be parsed
+     * @return user
+     */
+    User parseUser(long userId);
 }

--- a/core/src/main/java/ru/funpay4j/client/FunPayURL.java
+++ b/core/src/main/java/ru/funpay4j/client/FunPayURL.java
@@ -1,5 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.client;
 
+/**
+ * Base class for get FunPay base url
+ *
+ * @author panic08
+ * @since 1.0.0
+ */
 public class FunPayURL {
-    public static final String DEFAULT_URL = "https://funpay.com";
+    public static final String BASE_URL = "https://funpay.com";
 }

--- a/core/src/main/java/ru/funpay4j/core/FunPayExecutor.java
+++ b/core/src/main/java/ru/funpay4j/core/FunPayExecutor.java
@@ -1,8 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core;
 
 import lombok.NonNull;
 import okhttp3.OkHttpClient;
 import ru.funpay4j.client.FunPayParser;
+import ru.funpay4j.client.FunPayURL;
 import ru.funpay4j.client.jsoup.JsoupFunPayParser;
 import ru.funpay4j.core.commands.offer.GetOffer;
 import ru.funpay4j.core.commands.game.GetPromoGames;
@@ -29,7 +44,22 @@ public class FunPayExecutor {
 
     public FunPayExecutor() {
         OkHttpClient httpClient = new OkHttpClient();
-        this.funPayParser = new JsoupFunPayParser(httpClient);
+
+        this.funPayParser = new JsoupFunPayParser(httpClient, FunPayURL.BASE_URL);
+    }
+
+    public FunPayExecutor(@NonNull String baseURL, @NonNull Proxy proxy) {
+        OkHttpClient httpClient = new OkHttpClient.Builder()
+                .proxy(proxy)
+                .build();
+
+        this.funPayParser = new JsoupFunPayParser(httpClient, baseURL);
+    }
+
+    public FunPayExecutor(@NonNull String baseURL) {
+        OkHttpClient httpClient = new OkHttpClient();
+
+        this.funPayParser = new JsoupFunPayParser(httpClient, baseURL);
     }
 
     public FunPayExecutor(@NonNull Proxy proxy) {
@@ -37,46 +67,50 @@ public class FunPayExecutor {
                 .proxy(proxy)
                 .build();
 
-        this.funPayParser = new JsoupFunPayParser(httpClient);
+        this.funPayParser = new JsoupFunPayParser(httpClient, FunPayURL.BASE_URL);
     }
 
     /**
-     * Execute get lot command
+     * Execute to get lot
+     *
      * @param command command that will be executed
      * @return lot
      * @throws FunPayApiException if the lot with id does not exist or other api-related exception
      */
     public Lot execute(GetLot command) throws FunPayApiException {
-        return funPayParser.parse(command);
+        return funPayParser.parseLot(command.getLotId());
     }
 
     /**
-     * Execute get promoGames command
+     * Execute to get promoGames
+     *
      * @param command command that will be executed
      * @return promoGames
      * @throws FunPayApiException if api-related exception
      */
     public List<PromoGame> execute(GetPromoGames command) throws FunPayApiException {
-        return funPayParser.parse(command);
+        return funPayParser.parsePromoGames(command.getQuery());
     }
 
     /**
-     * Execute get offer command
+     * Execute to get offer
+     *
      * @param command command that will be executed
      * @return offer
      * @throws FunPayApiException if the offer with id does not exist or other api-related exception
      */
     public Offer execute(GetOffer command) throws FunPayApiException {
-        return funPayParser.parse(command);
+        return funPayParser.parseOffer(command.getOfferId());
     }
 
     /**
-     * Execute get user command
+     * Execute to get user
+     *
      * @param command command that will be executed
      * @return user
      * @throws FunPayApiException if the user with id does not exist or other api-related exception
      */
     public User execute(GetUser command) throws FunPayApiException {
-        return funPayParser.parse(command);
+        return funPayParser.parseUser(command.getUserId());
     }
 }

--- a/core/src/main/java/ru/funpay4j/core/commands/game/GetPromoGames.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/game/GetPromoGames.java
@@ -1,9 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.commands.game;
 
 import lombok.*;
 
 /**
- * Use this method to get PromoGames
+ * Use this command to get PromoGames
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/commands/lot/GetLot.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/lot/GetLot.java
@@ -1,9 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.commands.lot;
 
 import lombok.*;
 
 /**
- * Use this method to get Lot
+ * Use this command to get Lot
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/commands/offer/GetOffer.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/offer/GetOffer.java
@@ -1,9 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.commands.offer;
 
 import lombok.*;
 
 /**
- * Use this method to get PromoGames
+ * Use this command to get Offer
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/commands/user/GetUser.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/user/GetUser.java
@@ -1,9 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.commands.user;
 
 import lombok.*;
 
 /**
- * Use this method to get User
+ * Use this command to get User
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/exceptions/FunPayApiException.java
+++ b/core/src/main/java/ru/funpay4j/core/exceptions/FunPayApiException.java
@@ -1,7 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.exceptions;
 
 /**
- * Base class for any exception from FunPayClient
+ * Base class for any exception from FunPayExecutor
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/objects/game/PromoGame.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/game/PromoGame.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.objects.game;
 
 import lombok.AllArgsConstructor;

--- a/core/src/main/java/ru/funpay4j/core/objects/game/PromoGameCounter.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/game/PromoGameCounter.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.objects.game;
 
 import lombok.AllArgsConstructor;

--- a/core/src/main/java/ru/funpay4j/core/objects/lot/Lot.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/lot/Lot.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.objects.lot;
 
 import lombok.*;

--- a/core/src/main/java/ru/funpay4j/core/objects/lot/LotCounter.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/lot/LotCounter.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.objects.lot;
 
 import lombok.AllArgsConstructor;
@@ -16,7 +30,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class LotCounter {
-    private int lotId;
+    private long lotId;
 
     private String param;
 

--- a/core/src/main/java/ru/funpay4j/core/objects/offer/Offer.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/offer/Offer.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.objects.offer;
 
 import lombok.AllArgsConstructor;
@@ -5,7 +19,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import ru.funpay4j.core.objects.user.PreviewSeller;
-import ru.funpay4j.core.objects.user.PreviewUser;
 
 import java.util.List;
 import java.util.Map;

--- a/core/src/main/java/ru/funpay4j/core/objects/offer/PreviewOffer.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/offer/PreviewOffer.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.objects.offer;
 
 import lombok.AllArgsConstructor;
@@ -5,9 +19,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import ru.funpay4j.core.objects.user.PreviewSeller;
-import ru.funpay4j.core.objects.user.PreviewUser;
-
-import java.util.Objects;
 
 /**
  * This object represents the FunPay PreviewOffer

--- a/core/src/main/java/ru/funpay4j/core/objects/user/PreviewSeller.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/PreviewSeller.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.objects.user;
 
 import lombok.*;

--- a/core/src/main/java/ru/funpay4j/core/objects/user/PreviewUser.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/PreviewUser.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.objects.user;
 
 import lombok.AllArgsConstructor;

--- a/core/src/main/java/ru/funpay4j/core/objects/user/Seller.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/Seller.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.objects.user;
 
 import lombok.*;

--- a/core/src/main/java/ru/funpay4j/core/objects/user/SellerReview.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/SellerReview.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.objects.user;
 
 import lombok.AllArgsConstructor;

--- a/core/src/main/java/ru/funpay4j/core/objects/user/User.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/User.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.funpay4j.core.objects.user;
 
 import lombok.AllArgsConstructor;

--- a/core/src/test/java/FunPayExecutorTest.java
+++ b/core/src/test/java/FunPayExecutorTest.java
@@ -1,12 +1,23 @@
-package client;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import ru.funpay4j.client.jsoup.JsoupFunPayParser;
+import ru.funpay4j.core.FunPayExecutor;
 import ru.funpay4j.core.commands.offer.GetOffer;
 import ru.funpay4j.core.commands.game.GetPromoGames;
 import ru.funpay4j.core.commands.lot.GetLot;
@@ -27,8 +38,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author panic08
  * @since 1.0.0
  */
-class JsoupFunPayParserTest {
-    private JsoupFunPayParser parser;
+class FunPayExecutorTest {
+    private FunPayExecutor funPayExecutor;
     private MockWebServer mockWebServer;
 
     private static final String GET_USER_HTML_RESPONSE_PATH = "src/test/resources/html/client/getUserResponse.html";
@@ -39,7 +50,7 @@ class JsoupFunPayParserTest {
     @BeforeEach
     void setUp() {
         this.mockWebServer = new MockWebServer();
-        this.parser = new JsoupFunPayParser(new OkHttpClient(), this.mockWebServer.url("/").toString());
+        this.funPayExecutor = new FunPayExecutor(this.mockWebServer.url("/").toString());
     }
 
     @AfterEach
@@ -57,7 +68,7 @@ class JsoupFunPayParserTest {
                         .setResponseCode(200)
         );
 
-        Lot result = parser.parse(GetLot.builder().lotId(149).build());
+        Lot result = funPayExecutor.execute(GetLot.builder().lotId(149).build());
 
         assertNotNull(result);
         assertFalse(result.getPreviewOffers().isEmpty());
@@ -74,7 +85,7 @@ class JsoupFunPayParserTest {
                         .setResponseCode(200)
         );
 
-        List<PromoGame> result = parser.parse(GetPromoGames.builder().query("dota").build());
+        List<PromoGame> result = funPayExecutor.execute(GetPromoGames.builder().query("dota").build());
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -91,7 +102,7 @@ class JsoupFunPayParserTest {
                         .setResponseCode(200)
         );
 
-        Offer result = parser.parse(GetOffer.builder().offerId(33502824).build());
+        Offer result = funPayExecutor.execute(GetOffer.builder().offerId(33502824).build());
 
         assertNotNull(result);
         assertTrue(result.isAutoDelivery());
@@ -111,7 +122,7 @@ class JsoupFunPayParserTest {
                         .setResponseCode(200)
         );
 
-        Seller result = (Seller) parser.parse(GetUser.builder().userId(2).build());
+        Seller result = (Seller) funPayExecutor.execute(GetUser.builder().userId(2).build());
 
         assertNotNull(result);
         assertFalse(result.isOnline());

--- a/core/src/test/resources/html/client/getLotResponse.html
+++ b/core/src/test/resources/html/client/getLotResponse.html
@@ -1,3 +1,17 @@
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <div class="wrapper">
     <div class="wrapper-content">
         <header id="header">

--- a/core/src/test/resources/html/client/getOfferResponse.html
+++ b/core/src/test/resources/html/client/getOfferResponse.html
@@ -1,3 +1,17 @@
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <div class="wrapper">
     <div class="wrapper-content">
         <div class="corner-cd-container"><div class="corner-cd"><img src="https://sfunpay.com/s/file/uo/27/clash_royal_to.uo27h8yer9.jpg" alt=""></div></div>

--- a/core/src/test/resources/html/client/getUserResponse.html
+++ b/core/src/test/resources/html/client/getUserResponse.html
@@ -1,3 +1,17 @@
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <div id="content" class="content-users content-users-user"><div class="container profile-header">
     <div class="profile-cover">
         <div class="avatar">

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 #Fri Sep 13 21:21:43 MSK 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,13 +1,11 @@
 #!/bin/sh
 
 #
-# Copyright © 2015-2021 the original authors.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      https://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Here we have changed the use of the `FunPayParser` commander pattern.

In fact, it was a mistake to pass the `FunPayExecutor` and `FunPayParser` command at the same time.

We have also commented out the methods as needed, added copyright