### PR TITLE
Add support for unrated reviews

### DIFF
--- a/core/src/main/java/ru/funpay4j/client/jsoup/JsoupFunPayParser.java
+++ b/core/src/main/java/ru/funpay4j/client/jsoup/JsoupFunPayParser.java
@@ -396,17 +396,22 @@ public class JsoupFunPayParser implements FunPayParser {
                 List<Element> lastReviewElements = funPayDocument.getElementsByClass("review-container");
 
                 for (Element lastReviewElement : lastReviewElements) {
-                    Element reviewCompiledReview = lastReviewElement.getElementsByClass("review-compiled-review").first();
+                    Element reviewCompiledReviewElement = lastReviewElement.getElementsByClass("review-compiled-review").first();
+                    Element starsElement = reviewCompiledReviewElement.getElementsByClass("rating").first();
 
-                    String[] gameTitlePriceSplit = reviewCompiledReview.getElementsByClass("review-item-detail").text()
+                    String[] gameTitlePriceSplit = reviewCompiledReviewElement.getElementsByClass("review-item-detail").text()
                             .split(", ");
 
                     String gameTitle = gameTitlePriceSplit[0];
                     //Select a floating point number from a string like "from 1111.32 ₽"
                     double price = Double.parseDouble(gameTitlePriceSplit[1].replaceAll("[^0-9.]", "").split("\\s+")[0]);
-                    String text = reviewCompiledReview.getElementsByClass("review-item-text").text();
-                    int stars = Integer.parseInt(reviewCompiledReview.getElementsByClass("rating").first()
-                            .child(0).className().substring(6));
+                    String text = reviewCompiledReviewElement.getElementsByClass("review-item-text").text();
+                    int stars = 0;
+
+                    //if the review has rating
+                    if (starsElement != null) {
+                        stars = Integer.parseInt(starsElement.child(0).className().substring(6));
+                    }
 
                     lastReviews.add(SellerReview.builder()
                             .gameTitle(gameTitle)

--- a/core/src/test/resources/html/client/getUserResponse.html
+++ b/core/src/test/resources/html/client/getUserResponse.html
@@ -163,7 +163,6 @@
                                                     <div class="review-item-rating pull-right hidden-xs"><div class="rating"><div class="rating5"></div></div></div>
                                                     <div class="review-item-date">В этом месяце</div>
                                                     <div class="review-item-detail">Прочие игры, 10 ₽</div>
-                                                    <div class="review-item-rating visible-xs"><div class="rating"><div class="rating5"></div></div></div>
                                                 </div>
                                                 <div class="review-item-text">
                                                     Пообщаться с девушкой Кристиной здесь - https://funpay.com/users/336362/                                            </div>


### PR DESCRIPTION
This change will fix the situation where `JsoupFunPayParser` throws a `NullPointerException` if the user does not have a rating in the review