### PR TITLE
Add gameId field to Lot

### DIFF
--- a/core/src/main/java/ru/funpay4j/client/jsoup/JsoupFunPayParser.java
+++ b/core/src/main/java/ru/funpay4j/client/jsoup/JsoupFunPayParser.java
@@ -72,10 +72,16 @@ public class JsoupFunPayParser implements FunPayParser {
                 throw new FunPayApiException("Lot with lotId " + lotId + " does not exist");
             }
 
+            //take the second element, since we don't need a container from the element with the page-content-full class
+            //is named contentBodyContainer because it is the container on top of the content-body
+            Element funPayContentBodyContainerElement = funPayDocument.getElementById("content-body")
+                    .getElementsByClass("container")
+                    .get(1);
             Element funPayContentWithCdElement = funPayDocument.getElementsByClass("content-with-cd").first();
 
             String title = funPayContentWithCdElement.selectFirst("h1").text();
             String description = funPayContentWithCdElement.selectFirst("p").text();
+            long gameId = Long.parseLong(funPayContentBodyContainerElement.getElementsByClass("content-with-cd-wide showcase").attr("data-game"));
             List<LotCounter> lotCounters = new ArrayList<>();
             List<PreviewOffer> previewOffers = new ArrayList<>();
 
@@ -86,7 +92,7 @@ public class JsoupFunPayParser implements FunPayParser {
             for (Element counterItem : funPayCountersElements) {
                 String counterHrefAttributeValue = counterItem.attr("href");
 
-                //Skip chips, as they are not supported yet
+                //skip chips, as they are not supported yet
                 if (counterHrefAttributeValue.contains("chips")) continue;
 
                 long counterLotId = Integer.parseInt(counterHrefAttributeValue.substring(24, counterHrefAttributeValue.length() - 1));
@@ -107,7 +113,7 @@ public class JsoupFunPayParser implements FunPayParser {
                 );
             }
 
-            List<Element> funPayPreviewOffersElements = funPayDocument.getElementsByClass("tc")
+            List<Element> funPayPreviewOffersElements = funPayContentBodyContainerElement.getElementsByClass("tc")
                     .first()
                     .select("a");
 
@@ -158,6 +164,7 @@ public class JsoupFunPayParser implements FunPayParser {
                     .id(lotId)
                     .title(title)
                     .description(description)
+                    .gameId(gameId)
                     .lotCounters(lotCounters)
                     .previewOffers(previewOffers)
                     .build();

--- a/core/src/main/java/ru/funpay4j/core/objects/lot/Lot.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/lot/Lot.java
@@ -32,6 +32,8 @@ import java.util.List;
 public class Lot {
     private long id;
 
+    private long gameId;
+
     private String title;
 
     private String description;

--- a/core/src/test/java/ru/funpay4j/FunPayExecutorTest.java
+++ b/core/src/test/java/ru/funpay4j/FunPayExecutorTest.java
@@ -78,6 +78,7 @@ class FunPayExecutorTest {
         assertNotNull(result);
         assertFalse(result.getPreviewOffers().isEmpty());
         assertFalse(result.getLotCounters().isEmpty());
+        assertEquals(result.getGameId(), 41);
     }
 
     @Test


### PR DESCRIPTION
We need the `gameId` of a `Lot` so that we can interact with our offers in lots in specific games in the future (that's what the `gameId` is for)