### PR TITLE
Improve java doc

### DIFF
--- a/core/src/main/java/ru/funpay4j/client/FunPayClient.java
+++ b/core/src/main/java/ru/funpay4j/client/FunPayClient.java
@@ -28,21 +28,21 @@ public interface FunPayClient {
     /**
      * Send a request to update avatar
      *
-     * @param goldenKey goldenKey which will be used to authorize the user
+     * @param goldenKey golden key which will be used to authorize the user
      * @param newAvatar avatar to be updated
      * @throws FunPayApiException if the other api-related exception
-     * @throws InvalidGoldenKeyException if the goldenKey is invalid
+     * @throws InvalidGoldenKeyException if the golden key is invalid
      */
     void updateAvatar(String goldenKey, byte[] newAvatar) throws FunPayApiException, InvalidGoldenKeyException;
 
     /**
      * Send a request to raise all offers
      *
-     * @param goldenKey goldenKey which will be used to authorize the user
-     * @param gameId gameId for which offers will be raised
-     * @param lotId lotId for which offers will be raised
+     * @param goldenKey golden key which will be used to authorize the user
+     * @param gameId game id for which offers will be raised
+     * @param lotId lot id for which offers will be raised
      * @throws FunPayApiException if the other api-related exception
-     * @throws InvalidGoldenKeyException if the goldenKey is invalid
+     * @throws InvalidGoldenKeyException if the golden key is invalid
      * @throws OfferAlreadyRaisedException if the offer already raised
      */
     void raiseAllOffers(String goldenKey, long gameId, long lotId) throws FunPayApiException, InvalidGoldenKeyException, OfferAlreadyRaisedException;

--- a/core/src/main/java/ru/funpay4j/client/FunPayParser.java
+++ b/core/src/main/java/ru/funpay4j/client/FunPayParser.java
@@ -37,7 +37,7 @@ public interface FunPayParser {
     /**
      * Parse lot
      *
-     * @param lotId lotId by which lot will be parsed
+     * @param lotId lot id by which lot will be parsed
      * @return lot
      * @throws FunPayApiException if the other api-related exception
      * @throws LotNotFoundException if the lot with id does not found
@@ -45,10 +45,10 @@ public interface FunPayParser {
     Lot parseLot(long lotId) throws FunPayApiException, LotNotFoundException;
 
     /**
-     * Parse promoGames
+     * Parse promo games
      *
-     * @param query query by which promoGames will be parsed
-     * @return promoGames
+     * @param query query by which promo games will be parsed
+     * @return promo games
      * @throws FunPayApiException if the other api-related exception
      */
     List<PromoGame> parsePromoGames(String query) throws FunPayApiException;
@@ -56,7 +56,7 @@ public interface FunPayParser {
     /**
      * Parse offer
      *
-     * @param offerId offerId by which offer will be parsed
+     * @param offerId offer id by which offer will be parsed
      * @return offer
      * @throws FunPayApiException if the other api-related exception
      * @throws OfferNotFoundException if the offer with id does not found
@@ -66,7 +66,7 @@ public interface FunPayParser {
     /**
      * Parse user
      *
-     * @param userId userId by which user will be parsed
+     * @param userId user id by which user will be parsed
      * @return user
      * @throws FunPayApiException if the other api-related exception
      * @throws UserNotFoundException if the user with id does not found
@@ -76,7 +76,7 @@ public interface FunPayParser {
     /**
      * Parse seller reviews
      *
-     * @param userId userId by which seller reviews pages will be parsed
+     * @param userId user id by which seller reviews pages will be parsed
      * @param pages number of pages indicating how many seller reviews will be parsed
      * @param starsFilter number of stars by which the reviews will be parsed
      * @return sellerReviews
@@ -86,10 +86,10 @@ public interface FunPayParser {
     List<SellerReview> parseSellerReviews(long userId, int pages, Integer starsFilter) throws FunPayApiException, UserNotFoundException;
 
     /**
-     * Parse csrf and PHPSESSID
+     * Parse csrf-token and PHPSESSID
      *
-     * @param goldenKey goldenKey which will be used to authorize the user
-     * @return csrfToken and PHPSESSID
+     * @param goldenKey golden key which will be used to authorize the user
+     * @return csrf-token and PHPSESSID
      * @throws FunPayApiException if the other api-related exception
      */
     CsrfTokenAndPHPSESSID parseCsrfTokenAndPHPSESSID(String goldenKey) throws FunPayApiException;

--- a/core/src/main/java/ru/funpay4j/core/AuthorizedFunPayExecutor.java
+++ b/core/src/main/java/ru/funpay4j/core/AuthorizedFunPayExecutor.java
@@ -86,11 +86,11 @@ public class AuthorizedFunPayExecutor extends FunPayExecutor {
     }
 
     /**
-     * Execute to update avatar
+     * Execute to update user avatar
      *
      * @param command command that will be executed
      * @throws FunPayApiException if the other api-related exception
-     * @throws InvalidGoldenKeyException if the goldenKey is incorrect
+     * @throws InvalidGoldenKeyException if the golden key is incorrect
      */
     public void execute(UpdateAvatar command) throws FunPayApiException, InvalidGoldenKeyException {
         funPayClient.updateAvatar(goldenKey, command.getNewAvatar());
@@ -101,7 +101,7 @@ public class AuthorizedFunPayExecutor extends FunPayExecutor {
      *
      * @param command command that will be executed
      * @throws FunPayApiException if the other api-related exception
-     * @throws InvalidGoldenKeyException if the goldenKey is incorrect
+     * @throws InvalidGoldenKeyException if the golden key is incorrect
      * @throws OfferAlreadyRaisedException if the offer already raised
      */
     public void execute(RaiseAllOffers command) throws FunPayApiException, InvalidGoldenKeyException, OfferAlreadyRaisedException {

--- a/core/src/main/java/ru/funpay4j/core/FunPayExecutor.java
+++ b/core/src/main/java/ru/funpay4j/core/FunPayExecutor.java
@@ -96,10 +96,10 @@ public class FunPayExecutor {
     }
 
     /**
-     * Execute to get promoGames
+     * Execute to get promo games
      *
      * @param command command that will be executed
-     * @return promoGames
+     * @return promo games
      * @throws FunPayApiException if the other api-related exception
      */
     public List<PromoGame> execute(GetPromoGames command) throws FunPayApiException {
@@ -131,10 +131,10 @@ public class FunPayExecutor {
     }
 
     /**
-     * Execute to get sellerReviews
+     * Execute to get seller reviews
      *
      * @param command command that will be executed
-     * @return sellerReviews
+     * @return seller reviews
      * @throws FunPayApiException if the other api-related exception
      * @throws UserNotFoundException if the user with id does not found/seller
      */

--- a/core/src/main/java/ru/funpay4j/core/commands/game/GetPromoGames.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/game/GetPromoGames.java
@@ -17,7 +17,7 @@ package ru.funpay4j.core.commands.game;
 import lombok.*;
 
 /**
- * Use this command to get PromoGames
+ * Use this command to get promo games
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/commands/lot/GetLot.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/lot/GetLot.java
@@ -17,7 +17,7 @@ package ru.funpay4j.core.commands.lot;
 import lombok.*;
 
 /**
- * Use this command to get Lot
+ * Use this command to get lot
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/commands/offer/GetOffer.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/offer/GetOffer.java
@@ -17,7 +17,7 @@ package ru.funpay4j.core.commands.offer;
 import lombok.*;
 
 /**
- * Use this command to get Offer
+ * Use this command to get offer
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/commands/offer/RaiseAllOffers.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/offer/RaiseAllOffers.java
@@ -17,7 +17,7 @@ package ru.funpay4j.core.commands.offer;
 import lombok.*;
 
 /**
- * Use this command to raise all Offers
+ * Use this command to raise all offers
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/commands/user/GetUser.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/user/GetUser.java
@@ -17,7 +17,7 @@ package ru.funpay4j.core.commands.user;
 import lombok.*;
 
 /**
- * Use this command to get User
+ * Use this command to get user
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/commands/user/UpdateAvatar.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/user/UpdateAvatar.java
@@ -17,7 +17,7 @@ package ru.funpay4j.core.commands.user;
 import lombok.*;
 
 /**
- * Use this command to update avatar
+ * Use this command to update user avatar
  *
  * @author panic08
  * @since 1.0.3

--- a/core/src/main/java/ru/funpay4j/core/objects/game/PromoGame.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/game/PromoGame.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 
 /**
- * This object represents the FunPay PromoGame
+ * This object represents the FunPay promo game
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/objects/game/PromoGameCounter.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/game/PromoGameCounter.java
@@ -20,7 +20,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * This object represents the FunPay PromoGameCounter
+ * This object represents the FunPay promo game counter
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/objects/lot/Lot.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/lot/Lot.java
@@ -20,7 +20,7 @@ import ru.funpay4j.core.objects.offer.PreviewOffer;
 import java.util.List;
 
 /**
- * This object represents the FunPay Lot
+ * This object represents the FunPay lot
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/objects/lot/LotCounter.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/lot/LotCounter.java
@@ -20,7 +20,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * This object represents the FunPay LotCounter
+ * This object represents the FunPay lot counter
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/objects/offer/Offer.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/offer/Offer.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * This object represents the FunPay Offer
+ * This object represents the FunPay offer
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/objects/offer/PreviewOffer.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/offer/PreviewOffer.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 import ru.funpay4j.core.objects.user.PreviewSeller;
 
 /**
- * This object represents the FunPay PreviewOffer
+ * This object represents the FunPay preview offer
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/objects/user/PreviewSeller.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/PreviewSeller.java
@@ -18,7 +18,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 /**
- * This object represents the FunPay PreviewSeller
+ * This object represents the FunPay preview seller
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/objects/user/PreviewUser.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/PreviewUser.java
@@ -21,7 +21,7 @@ import lombok.experimental.SuperBuilder;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * This object represents the FunPay PreviewUser
+ * This object represents the FunPay preview user
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/objects/user/Seller.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/Seller.java
@@ -21,7 +21,7 @@ import ru.funpay4j.core.objects.offer.PreviewOffer;
 import java.util.List;
 
 /**
- * This object represents the FunPay Seller
+ * This object represents the FunPay seller
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/objects/user/SellerReview.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/SellerReview.java
@@ -20,7 +20,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * This object represents the FunPay Seller Review
+ * This object represents the FunPay seller review
  *
  * @author panic08
  * @since 1.0.0

--- a/core/src/main/java/ru/funpay4j/core/objects/user/User.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/User.java
@@ -24,7 +24,7 @@ import java.util.Date;
 import java.util.List;
 
 /**
- * This object represents the FunPay User
+ * This object represents the FunPay user
  *
  * @author panic08
  * @since 1.0.0


### PR DESCRIPTION
I think we need this as we have used camelcase in different components then camelcase in javadoc when mentioning variables, then other cases. So I propose to bring the mentioning of variables under 1 option