### PR TITLE
Remove repeated text about license

### DIFF
--- a/core/src/main/java/ru/funpay4j/core/commands/user/GetSellerReviews.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/user/GetSellerReviews.java
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ru.funpay4j.core.commands.user;
 
 import lombok.*;

--- a/core/src/main/java/ru/funpay4j/core/exceptions/lot/LotNotFoundException.java
+++ b/core/src/main/java/ru/funpay4j/core/exceptions/lot/LotNotFoundException.java
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ru.funpay4j.core.exceptions.lot;
 
 /**

--- a/core/src/main/java/ru/funpay4j/util/FunPayUserUtil.java
+++ b/core/src/main/java/ru/funpay4j/util/FunPayUserUtil.java
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ru.funpay4j.util;
 
 import lombok.NonNull;

--- a/core/src/test/java/ru/funpay4j/util/FunPayUserUtilLastSeenAtConverterTest.java
+++ b/core/src/test/java/ru/funpay4j/util/FunPayUserUtilLastSeenAtConverterTest.java
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ru.funpay4j.util;
 
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/ru/funpay4j/util/FunPayUserUtilRegisterDateConverterTest.java
+++ b/core/src/test/java/ru/funpay4j/util/FunPayUserUtilRegisterDateConverterTest.java
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ru.funpay4j.util;
 
 import org.junit.jupiter.api.Test;

--- a/examples/src/main/java/ru/funpay4j/examples/game/GetPromoGames.java
+++ b/examples/src/main/java/ru/funpay4j/examples/game/GetPromoGames.java
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ru.funpay4j.examples.game;
 
 import ru.funpay4j.core.FunPayExecutor;

--- a/examples/src/main/java/ru/funpay4j/examples/lot/GetLot.java
+++ b/examples/src/main/java/ru/funpay4j/examples/lot/GetLot.java
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ru.funpay4j.examples.lot;
 
 import ru.funpay4j.core.FunPayExecutor;

--- a/examples/src/main/java/ru/funpay4j/examples/offer/GetOffer.java
+++ b/examples/src/main/java/ru/funpay4j/examples/offer/GetOffer.java
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ru.funpay4j.examples.offer;
 
 import ru.funpay4j.core.FunPayExecutor;

--- a/examples/src/main/java/ru/funpay4j/examples/offer/RaiseAllOffers.java
+++ b/examples/src/main/java/ru/funpay4j/examples/offer/RaiseAllOffers.java
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ru.funpay4j.examples.offer;
 
 import ru.funpay4j.core.AuthorizedFunPayExecutor;

--- a/examples/src/main/java/ru/funpay4j/examples/user/GetSellerReviews.java
+++ b/examples/src/main/java/ru/funpay4j/examples/user/GetSellerReviews.java
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ru.funpay4j.examples.user;
 
 import ru.funpay4j.core.FunPayExecutor;

--- a/examples/src/main/java/ru/funpay4j/examples/user/GetUser.java
+++ b/examples/src/main/java/ru/funpay4j/examples/user/GetUser.java
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ru.funpay4j.examples.user;
 
 import ru.funpay4j.core.FunPayExecutor;

--- a/examples/src/main/java/ru/funpay4j/examples/user/UpdateAvatar.java
+++ b/examples/src/main/java/ru/funpay4j/examples/user/UpdateAvatar.java
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ru.funpay4j.examples.user;
 
 import ru.funpay4j.core.AuthorizedFunPayExecutor;


### PR DESCRIPTION
Oddly enough, some of the license was duplicated in some classes according to some errors. I think we should definitely clean that up