### PR TITLE
Switch from primitives to wrapper classes in commands

### DIFF
--- a/core/src/main/java/ru/funpay4j/client/jsoup/JsoupFunPayParser.java
+++ b/core/src/main/java/ru/funpay4j/client/jsoup/JsoupFunPayParser.java
@@ -488,7 +488,7 @@ public class JsoupFunPayParser implements FunPayParser {
      * {@inheritDoc}
      */
     @Override
-    public List<SellerReview> parseSellerReviews(long userId, int pages, @Nullable Integer starsFilter) throws FunPayApiException, UserNotFoundException {
+    public List<SellerReview> parseSellerReviews(long userId, int pages, Integer starsFilter) throws FunPayApiException, UserNotFoundException {
         List<SellerReview> currentSellerReviews = new ArrayList<>();
 
         String userIdFormData = String.valueOf(userId);

--- a/core/src/main/java/ru/funpay4j/core/commands/game/GetPromoGames.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/game/GetPromoGames.java
@@ -26,7 +26,6 @@ import lombok.*;
 @Setter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
 public class GetPromoGames {
     @NonNull
     private String query;

--- a/core/src/main/java/ru/funpay4j/core/commands/lot/GetLot.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/lot/GetLot.java
@@ -26,7 +26,7 @@ import lombok.*;
 @Setter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
 public class GetLot {
-    private long lotId;
+    @NonNull
+    private Long lotId;
 }

--- a/core/src/main/java/ru/funpay4j/core/commands/offer/GetOffer.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/offer/GetOffer.java
@@ -26,7 +26,7 @@ import lombok.*;
 @Setter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
 public class GetOffer {
-    private long offerId;
+    @NonNull
+    private Long offerId;
 }

--- a/core/src/main/java/ru/funpay4j/core/commands/offer/RaiseAllOffers.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/offer/RaiseAllOffers.java
@@ -26,9 +26,10 @@ import lombok.*;
 @Setter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
 public class RaiseAllOffers {
-    private long gameId;
+    @NonNull
+    private Long gameId;
 
-    private long lotId;
+    @NonNull
+    private Long lotId;
 }

--- a/core/src/main/java/ru/funpay4j/core/commands/user/GetSellerReviews.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/user/GetSellerReviews.java
@@ -27,11 +27,12 @@ import org.jetbrains.annotations.Nullable;
 @Setter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
 public class GetSellerReviews {
-    private long userId;
+    @NonNull
+    private Long userId;
 
-    private int pages;
+    @NonNull
+    private Integer pages;
 
     @Nullable
     private Integer starsFilter;

--- a/core/src/main/java/ru/funpay4j/core/commands/user/GetUser.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/user/GetUser.java
@@ -26,7 +26,7 @@ import lombok.*;
 @Setter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
 public class GetUser {
-    private long userId;
+    @NonNull
+    private Long userId;
 }

--- a/core/src/main/java/ru/funpay4j/core/commands/user/UpdateAvatar.java
+++ b/core/src/main/java/ru/funpay4j/core/commands/user/UpdateAvatar.java
@@ -26,7 +26,6 @@ import lombok.*;
 @Setter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
 public class UpdateAvatar {
     private byte @NonNull [] newAvatar;
 }

--- a/core/src/main/java/ru/funpay4j/core/objects/CsrfTokenAndPHPSESSID.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/CsrfTokenAndPHPSESSID.java
@@ -14,10 +14,12 @@
 
 package ru.funpay4j.core.objects;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 @Builder
 public class CsrfTokenAndPHPSESSID {
     private String csrfToken;

--- a/core/src/main/java/ru/funpay4j/core/objects/game/PromoGame.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/game/PromoGame.java
@@ -17,7 +17,6 @@ package ru.funpay4j.core.objects.game;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
@@ -29,7 +28,6 @@ import java.util.List;
  */
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 @Builder
 public class PromoGame {
     private long lotId;

--- a/core/src/main/java/ru/funpay4j/core/objects/game/PromoGameCounter.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/game/PromoGameCounter.java
@@ -17,7 +17,6 @@ package ru.funpay4j.core.objects.game;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * This object represents the FunPay promo game counter
@@ -27,7 +26,6 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 @Builder
 public class PromoGameCounter {
     private long lotId;

--- a/core/src/main/java/ru/funpay4j/core/objects/lot/Lot.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/lot/Lot.java
@@ -27,7 +27,6 @@ import java.util.List;
  */
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 @Builder
 public class Lot {
     private long id;

--- a/core/src/main/java/ru/funpay4j/core/objects/lot/LotCounter.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/lot/LotCounter.java
@@ -17,7 +17,6 @@ package ru.funpay4j.core.objects.lot;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * This object represents the FunPay lot counter
@@ -27,7 +26,6 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 @Builder
 public class LotCounter {
     private long lotId;

--- a/core/src/main/java/ru/funpay4j/core/objects/offer/Offer.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/offer/Offer.java
@@ -17,7 +17,6 @@ package ru.funpay4j.core.objects.offer;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import ru.funpay4j.core.objects.user.PreviewSeller;
 
 import java.util.List;
@@ -31,7 +30,6 @@ import java.util.Map;
  */
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 @Builder
 public class Offer {
     private long id;

--- a/core/src/main/java/ru/funpay4j/core/objects/offer/PreviewOffer.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/offer/PreviewOffer.java
@@ -17,7 +17,6 @@ package ru.funpay4j.core.objects.offer;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import ru.funpay4j.core.objects.user.PreviewSeller;
 
 /**
@@ -28,7 +27,6 @@ import ru.funpay4j.core.objects.user.PreviewSeller;
  */
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 @Builder
 public class PreviewOffer {
     private long offerId;

--- a/core/src/main/java/ru/funpay4j/core/objects/user/PreviewSeller.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/PreviewSeller.java
@@ -27,7 +27,6 @@ import lombok.experimental.SuperBuilder;
 @Setter
 @EqualsAndHashCode(callSuper = true)
 @AllArgsConstructor
-@NoArgsConstructor
 @ToString(callSuper = true)
 @SuperBuilder
 public class PreviewSeller extends PreviewUser {

--- a/core/src/main/java/ru/funpay4j/core/objects/user/Seller.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/Seller.java
@@ -30,7 +30,6 @@ import java.util.List;
 @Setter
 @EqualsAndHashCode(callSuper = true)
 @AllArgsConstructor
-@NoArgsConstructor
 @ToString(callSuper = true)
 @SuperBuilder
 public class Seller extends User {

--- a/core/src/main/java/ru/funpay4j/core/objects/user/SellerReview.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/SellerReview.java
@@ -17,7 +17,6 @@ package ru.funpay4j.core.objects.user;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * This object represents the FunPay seller review
@@ -27,7 +26,6 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 @Builder
 public class SellerReview {
     private String gameTitle;

--- a/core/src/test/java/ru/funpay4j/AuthorizedFunPayExecutorTest.java
+++ b/core/src/test/java/ru/funpay4j/AuthorizedFunPayExecutorTest.java
@@ -111,7 +111,7 @@ class AuthorizedFunPayExecutorTest {
         );
 
         assertThrows(InvalidGoldenKeyException.class, () -> {
-            funPayExecutor.execute(RaiseAllOffers.builder().lotId(1).gameId(1).build());
+            funPayExecutor.execute(RaiseAllOffers.builder().lotId(1L).gameId(1L).build());
         });
     }
 
@@ -124,7 +124,7 @@ class AuthorizedFunPayExecutorTest {
         );
 
         assertThrows(OfferAlreadyRaisedException.class, () -> {
-            funPayExecutor.execute(RaiseAllOffers.builder().lotId(1).gameId(1).build());
+            funPayExecutor.execute(RaiseAllOffers.builder().lotId(1L).gameId(1L).build());
         });
     }
 

--- a/core/src/test/java/ru/funpay4j/FunPayExecutorTest.java
+++ b/core/src/test/java/ru/funpay4j/FunPayExecutorTest.java
@@ -73,7 +73,7 @@ class FunPayExecutorTest {
                         .setResponseCode(200)
         );
 
-        Lot result = funPayExecutor.execute(GetLot.builder().lotId(149).build());
+        Lot result = funPayExecutor.execute(GetLot.builder().lotId(149L).build());
 
         assertNotNull(result);
         assertFalse(result.getPreviewOffers().isEmpty());
@@ -108,7 +108,7 @@ class FunPayExecutorTest {
                         .setResponseCode(200)
         );
 
-        Offer result = funPayExecutor.execute(GetOffer.builder().offerId(33502824).build());
+        Offer result = funPayExecutor.execute(GetOffer.builder().offerId(33502824L).build());
 
         assertNotNull(result);
         assertTrue(result.isAutoDelivery());
@@ -128,7 +128,7 @@ class FunPayExecutorTest {
                         .setResponseCode(200)
         );
 
-        Seller result = (Seller) funPayExecutor.execute(GetUser.builder().userId(2).build());
+        Seller result = (Seller) funPayExecutor.execute(GetUser.builder().userId(2L).build());
 
         assertNotNull(result);
         assertNotNull(result.getRegisteredAt());
@@ -148,7 +148,7 @@ class FunPayExecutorTest {
                         .setResponseCode(200)
         );
 
-        List<SellerReview> result = funPayExecutor.execute(GetSellerReviews.builder().pages(1).userId(2).build());
+        List<SellerReview> result = funPayExecutor.execute(GetSellerReviews.builder().pages(1).userId(2L).build());
 
         assertFalse(result.isEmpty());
     }

--- a/examples/src/main/java/ru/funpay4j/examples/lot/GetLot.java
+++ b/examples/src/main/java/ru/funpay4j/examples/lot/GetLot.java
@@ -38,7 +38,7 @@ public class GetLot {
 
         try {
             lot = executor.execute(ru.funpay4j.core.commands.lot.GetLot.builder()
-                    .lotId(81)
+                    .lotId(81L)
                     .build());
 
             System.out.println(lot);

--- a/examples/src/main/java/ru/funpay4j/examples/offer/GetOffer.java
+++ b/examples/src/main/java/ru/funpay4j/examples/offer/GetOffer.java
@@ -38,7 +38,7 @@ public class GetOffer {
 
         try {
             offer = executor.execute(ru.funpay4j.core.commands.offer.GetOffer.builder()
-                    .offerId(26021761)
+                    .offerId(26021761L)
                     .build());
 
             System.out.println(offer);

--- a/examples/src/main/java/ru/funpay4j/examples/offer/RaiseAllOffers.java
+++ b/examples/src/main/java/ru/funpay4j/examples/offer/RaiseAllOffers.java
@@ -36,8 +36,8 @@ public class RaiseAllOffers {
 
         try {
             authorizedExecutor.execute(ru.funpay4j.core.commands.offer.RaiseAllOffers.builder()
-                    .lotId(123)
-                    .gameId(123)
+                    .lotId(123L)
+                    .gameId(123L)
                     .build());
         } catch (FunPayApiException e) {
             throw new RuntimeException(e);

--- a/examples/src/main/java/ru/funpay4j/examples/user/GetSellerReviews.java
+++ b/examples/src/main/java/ru/funpay4j/examples/user/GetSellerReviews.java
@@ -41,7 +41,7 @@ public class GetSellerReviews {
         try {
             sellerReviews = executor.execute(ru.funpay4j.core.commands.user.GetSellerReviews.builder()
                     .pages(2)
-                    .userId(1940073)
+                    .userId(1940073L)
                     .starsFilter(null)
                     .build());
 

--- a/examples/src/main/java/ru/funpay4j/examples/user/GetUser.java
+++ b/examples/src/main/java/ru/funpay4j/examples/user/GetUser.java
@@ -39,7 +39,7 @@ public class GetUser {
 
         try {
             user = executor.execute(ru.funpay4j.core.commands.user.GetUser.builder()
-                    .userId(1940073)
+                    .userId(1940073L)
                     .build());
 
             System.out.println(user);


### PR DESCRIPTION
I think it'll be good for us. Now users will have to specify some fields like id manually. This fix can be considered great I guess, because a user could create a conditionally empty `GetLot` without an id, and the id would automatically become 0 and the request would pass. But now he will have to do it manually