### PR TITLE
Remove PHPSESSID and csrf-token update when initializing AuthorizedFunPayExecutor instance and make it lazy

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="corretto-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="corretto-1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/core/src/main/java/ru/funpay4j/core/AuthorizedFunPayExecutor.java
+++ b/core/src/main/java/ru/funpay4j/core/AuthorizedFunPayExecutor.java
@@ -52,11 +52,6 @@ public class AuthorizedFunPayExecutor extends FunPayExecutor {
         super();
 
         this.goldenKey = goldenKey;
-        try {
-            updateCsrfTokenAndPHPSESSID();
-        } catch (FunPayApiException e) {
-            throw new RuntimeException(e.getCause());
-        }
     }
 
     /**
@@ -70,11 +65,6 @@ public class AuthorizedFunPayExecutor extends FunPayExecutor {
         super(baseURL, proxy);
 
         this.goldenKey = goldenKey;
-        try {
-            updateCsrfTokenAndPHPSESSID();
-        } catch (FunPayApiException e) {
-            throw new RuntimeException(e.getCause());
-        }
     }
 
     /**
@@ -87,11 +77,6 @@ public class AuthorizedFunPayExecutor extends FunPayExecutor {
         super(baseURL);
 
         this.goldenKey = goldenKey;
-        try {
-            updateCsrfTokenAndPHPSESSID();
-        } catch (FunPayApiException e) {
-            throw new RuntimeException(e.getCause());
-        }
     }
 
     /**
@@ -104,11 +89,6 @@ public class AuthorizedFunPayExecutor extends FunPayExecutor {
         super(proxy);
 
         this.goldenKey = goldenKey;
-        try {
-            updateCsrfTokenAndPHPSESSID();
-        } catch (FunPayApiException e) {
-            throw new RuntimeException(e.getCause());
-        }
     }
 
     /**
@@ -160,6 +140,14 @@ public class AuthorizedFunPayExecutor extends FunPayExecutor {
                 .amount(command.getAmount())
                 .build();
 
+        if (PHPSESSID == null || csrfToken == null) {
+            try {
+                updateCsrfTokenAndPHPSESSID();
+            } catch (FunPayApiException e) {
+                throw new RuntimeException(e.getCause());
+            }
+        }
+
         //attempt to regenerate csrfToken and PHPSESSID
         try {
             funPayClient.saveOffer(goldenKey, csrfToken, PHPSESSID, request);
@@ -202,6 +190,14 @@ public class AuthorizedFunPayExecutor extends FunPayExecutor {
                 .amount(command.getAmount())
                 .build();
 
+        if (PHPSESSID == null || csrfToken == null) {
+            try {
+                updateCsrfTokenAndPHPSESSID();
+            } catch (FunPayApiException e) {
+                throw new RuntimeException(e.getCause());
+            }
+        }
+
         //attempt to regenerate csrfToken and PHPSESSID
         try {
             funPayClient.saveOffer(goldenKey, csrfToken, PHPSESSID, request);
@@ -230,6 +226,14 @@ public class AuthorizedFunPayExecutor extends FunPayExecutor {
                 .offerId(command.getOfferId())
                 .isDeleted(true)
                 .build();
+
+        if (PHPSESSID == null || csrfToken == null) {
+            try {
+                updateCsrfTokenAndPHPSESSID();
+            } catch (FunPayApiException e) {
+                throw new RuntimeException(e.getCause());
+            }
+        }
 
         //attempt to regenerate csrfToken and PHPSESSID
         try {

--- a/core/src/test/java/ru/funpay4j/AuthorizedFunPayExecutorTest.java
+++ b/core/src/test/java/ru/funpay4j/AuthorizedFunPayExecutorTest.java
@@ -46,18 +46,8 @@ class AuthorizedFunPayExecutorTest {
     @BeforeEach
     void setUp() throws Exception {
         this.mockWebServer = new MockWebServer();
-
-        //we do this because when creating a new instance of AuthorizedFunPayExecutor in the constructor, csrfToken and PHPSESSID are obtained
-        String htmlContent = new String(Files.readAllBytes(Paths.get(GET_CSRF_TOKEN_AND_PHPSESSID_HTML_RESPONSE_PATH)));
-
-        mockWebServer.enqueue(
-                new MockResponse()
-                        .setBody(htmlContent)
-                        .setHeader("Set-Cookie", "PHPSESSID=old;")
-                        .setResponseCode(200)
-        );
-
         this.funPayExecutor = new AuthorizedFunPayExecutor("example", this.mockWebServer.url("/").toString());
+        this.funPayExecutor.setPHPSESSID("old");
         this.funPayExecutor.setCsrfToken("old");
     }
 


### PR DESCRIPTION
I believe this update will be good for us. Since we use the `updateCsrfTokenAndPHPSESSID()` method when updating csrf-token and PHPSESSID, it gets the html from the csrf under the hood and also gets the PHPSESSID from the request. I also believe that there are scenarios where a user creates an `AuthorizedFunPayExecutor` instance and specifies a proxy there, then wants to use methods for which csrf-token and PHPSESSID are unnecessary, but in the current implementation they will be updated and this user's proxy will load the html page

Also, there was a crutch in the tests, when we `setUp()` when creating `AuthorizedFunPayExecutor` instance before setting response in the server, because we always have PHPSESSID updated when creating this instance