### PR TITLE
Improve code readability by unifying parseSellerReviews implementation

### DIFF
--- a/core/src/main/java/ru/funpay4j/client/FunPayParser.java
+++ b/core/src/main/java/ru/funpay4j/client/FunPayParser.java
@@ -78,12 +78,23 @@ public interface FunPayParser {
      *
      * @param userId user id by which seller reviews pages will be parsed
      * @param pages number of pages indicating how many seller reviews will be parsed
+     * @return sellerReviews
+     * @throws FunPayApiException if the other api-related exception
+     * @throws UserNotFoundException if the user with id does not found/seller
+     */
+    List<SellerReview> parseSellerReviews(long userId, int pages) throws FunPayApiException, UserNotFoundException;
+
+    /**
+     * Parse seller reviews with stars filter
+     *
+     * @param userId user id by which seller reviews pages will be parsed
+     * @param pages number of pages indicating how many seller reviews will be parsed
      * @param starsFilter number of stars by which the reviews will be parsed
      * @return sellerReviews
      * @throws FunPayApiException if the other api-related exception
      * @throws UserNotFoundException if the user with id does not found/seller
      */
-    List<SellerReview> parseSellerReviews(long userId, int pages, Integer starsFilter) throws FunPayApiException, UserNotFoundException;
+    List<SellerReview> parseSellerReviews(long userId, int pages, int starsFilter) throws FunPayApiException, UserNotFoundException;
 
     /**
      * Parse csrf-token and PHPSESSID

--- a/core/src/main/java/ru/funpay4j/core/FunPayExecutor.java
+++ b/core/src/main/java/ru/funpay4j/core/FunPayExecutor.java
@@ -158,6 +158,10 @@ public class FunPayExecutor {
      * @throws UserNotFoundException if the user with id does not found/seller
      */
     public List<SellerReview> execute(GetSellerReviews command) throws FunPayApiException, UserNotFoundException {
-        return funPayParser.parseSellerReviews(command.getUserId(), command.getPages(), command.getStarsFilter());
+        if (command.getStarsFilter() != null) {
+            return funPayParser.parseSellerReviews(command.getUserId(), command.getPages(), command.getStarsFilter());
+        } else {
+            return funPayParser.parseSellerReviews(command.getUserId(), command.getPages());
+        }
     }
 }


### PR DESCRIPTION
Here we are clearly improving readability in FunPayClient and the logic itself by overflowing `parseSellerReviews`