### PR TITLE
Add “createdAt” to AdvancedSellerReview

### DIFF
--- a/core/src/main/java/ru/funpay4j/client/jsoup/JsoupFunPayParser.java
+++ b/core/src/main/java/ru/funpay4j/client/jsoup/JsoupFunPayParser.java
@@ -666,27 +666,40 @@ public class JsoupFunPayParser implements FunPayParser {
             }
 
             Element mediaUsernameElement = reviewCompiledReviewElement.getElementsByClass("media-user-name").first();
-            Element reviewItemOrder = reviewCompiledReviewElement.getElementsByClass("review-item-order").first();
-            Element reviewItemPhoto = reviewCompiledReviewElement.getElementsByClass("review-item-photo").first();
+            Element reviewItemOrderElement = reviewCompiledReviewElement.getElementsByClass("review-item-order").first();
+            Element reviewItemPhotoElement = reviewCompiledReviewElement.getElementsByClass("review-item-photo").first();
+            Element reviewItemDateElement = reviewCompiledReviewElement.getElementsByClass("review-item-date").first();
 
-            if (mediaUsernameElement != null && reviewItemOrder != null && reviewItemPhoto.child(0).childrenSize() > 0) {
+            if (mediaUsernameElement != null && reviewItemOrderElement != null && reviewItemPhotoElement.child(0).childrenSize() > 0) {
                 String mediaUsernameHrefAttributeValue = mediaUsernameElement.child(0).attr("href");
-                String reviewItemPhotoSrcAttributeValue = reviewItemPhoto.child(0).child(0).attr("src");
+                String reviewItemPhotoSrcAttributeValue = reviewItemPhotoElement.child(0).child(0).attr("src");
+                String reviewItemOrderHrefAttributeValue = reviewItemOrderElement.child(0).attr("href");
 
                 long lastReviewSenderUserId = Long.parseLong(mediaUsernameHrefAttributeValue.substring(25, mediaUsernameHrefAttributeValue.length() - 1));
+                String lastReviewOrderId = reviewItemOrderHrefAttributeValue.substring(26, reviewItemOrderHrefAttributeValue.length() - 1);
                 String lastReviewSenderUsername = mediaUsernameElement.child(0).text();
                 String lastReviewSenderAvatarPhotoLink = reviewItemPhotoSrcAttributeValue.equals("/img/layout/avatar.png") ? null
                         : reviewItemPhotoSrcAttributeValue;
+                Date lastReviewCreatedAtDate = null;
+
+                try {
+                    lastReviewCreatedAtDate = FunPayUserUtil.convertAdvancedSellerReviewCreatedAtToDate(reviewItemDateElement.text());
+                } catch (ParseException e) {
+                    e.printStackTrace();
+                }
+
 
                 currentSellerReviews.add(AdvancedSellerReview.builder()
                         .gameTitle(lastReviewGameTitle)
                         .price(lastReviewPrice)
                         .text(lastReviewText)
                         .stars(lastReviewStars)
+                        .orderId(lastReviewOrderId)
                         .sellerReplyText(lastReviewAnswer)
                         .senderUserId(lastReviewSenderUserId)
                         .senderUsername(lastReviewSenderUsername)
                         .senderAvatarLink(lastReviewSenderAvatarPhotoLink)
+                        .createdAt(lastReviewCreatedAtDate)
                         .build());
             } else {
                 currentSellerReviews.add(SellerReview.builder()

--- a/core/src/main/java/ru/funpay4j/core/objects/user/AdvancedSellerReview.java
+++ b/core/src/main/java/ru/funpay4j/core/objects/user/AdvancedSellerReview.java
@@ -17,6 +17,8 @@ package ru.funpay4j.core.objects.user;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
+import java.util.Date;
+
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = true)
@@ -31,4 +33,6 @@ public class AdvancedSellerReview extends SellerReview {
     private String senderAvatarLink;
 
     private String orderId;
+
+    private Date createdAt;
 }

--- a/core/src/main/java/ru/funpay4j/util/FunPayUserUtil.java
+++ b/core/src/main/java/ru/funpay4j/util/FunPayUserUtil.java
@@ -167,6 +167,73 @@ public class FunPayUserUtil {
         return null;
     }
 
+    /**
+     * Converts a string representation of the advanced seller review created at date to a {@link Date} object
+     *
+     * @param createdAt the date of created at as a string that needs to be converted
+     * @return {@link Date} object representing the parsed date and time
+     * @throws ParseException parsing exception
+     */
+    public static Date convertAdvancedSellerReviewCreatedAtToDate(@NonNull String createdAt) throws ParseException {
+        if (createdAt.startsWith("сегодня")) {
+            Calendar calendar = Calendar.getInstance();
 
+            SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm", Locale.forLanguageTag("ru"));
+
+            String time = createdAt.split(", ")[1];
+            Date parsedDate = dateFormat.parse(time);
+
+            calendar.set(Calendar.HOUR_OF_DAY, parsedDate.getHours());
+            calendar.set(Calendar.MINUTE, parsedDate.getMinutes());
+            calendar.set(Calendar.SECOND, 0);
+            calendar.set(Calendar.MILLISECOND, 0);
+
+            return calendar.getTime();
+
+        } else if (createdAt.startsWith("вчера")) {
+            Calendar calendar = Calendar.getInstance();
+
+            SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm", Locale.forLanguageTag("ru"));
+
+            String time = createdAt.split(", ")[1];
+            Date parsedDate = dateFormat.parse(time);
+
+            calendar.add(Calendar.DAY_OF_MONTH, -1);
+            calendar.set(Calendar.HOUR_OF_DAY, parsedDate.getHours());
+            calendar.set(Calendar.MINUTE, parsedDate.getMinutes());
+            calendar.set(Calendar.SECOND, 0);
+            calendar.set(Calendar.MILLISECOND, 0);
+
+            return calendar.getTime();
+
+        } else {
+            if (createdAt.contains(",")) {
+                Calendar calendar = Calendar.getInstance();
+
+                if (createdAt.split(", ")[0].matches(".*\\d{4}.*")) {
+                    //if the row contains a year
+
+                    SimpleDateFormat dateFormatWithYear = new SimpleDateFormat("d MMMM yyyy в HH:mm", Locale.forLanguageTag("ru"));
+
+                    Date parsedDate = dateFormatWithYear.parse(createdAt);
+
+                    calendar.setTime(parsedDate);
+                } else {
+                    SimpleDateFormat dateFormatWithoutYear = new SimpleDateFormat("d MMMM в HH:mm", Locale.forLanguageTag("ru"));
+
+                    Date parsedDate = dateFormatWithoutYear.parse(createdAt);
+
+                    calendar.setTime(parsedDate);
+                    calendar.set(Calendar.YEAR, Calendar.getInstance().get(Calendar.YEAR));
+                    calendar.set(Calendar.SECOND, 0);
+                    calendar.set(Calendar.MILLISECOND, 0);
+                }
+
+                return calendar.getTime();
+            }
+
+            return null;
+        }
+    }
 
 }

--- a/core/src/test/java/ru/funpay4j/FunPayExecutorTest.java
+++ b/core/src/test/java/ru/funpay4j/FunPayExecutorTest.java
@@ -28,6 +28,7 @@ import ru.funpay4j.core.commands.user.GetUser;
 import ru.funpay4j.core.objects.game.PromoGame;
 import ru.funpay4j.core.objects.lot.Lot;
 import ru.funpay4j.core.objects.offer.Offer;
+import ru.funpay4j.core.objects.user.AdvancedSellerReview;
 import ru.funpay4j.core.objects.user.Seller;
 import ru.funpay4j.core.objects.user.SellerReview;
 
@@ -150,10 +151,16 @@ class FunPayExecutorTest {
 
         List<SellerReview> result = funPayExecutor.execute(GetSellerReviews.builder().pages(1).userId(2L).build());
 
-        assertFalse(result.isEmpty());
         assertEquals(2, result.size());
 
-        SellerReview firstSellerReview = result.get(0);
+        AdvancedSellerReview firstSellerReview = (AdvancedSellerReview) result.get(0);
+        assertNotNull(firstSellerReview.getSenderUsername());
+        assertNotNull(firstSellerReview.getOrderId());
+        assertNull(firstSellerReview.getSenderAvatarLink());
+        assertNotNull(firstSellerReview.getText());
+        assertNotNull(firstSellerReview.getGameTitle());
+        assertNotNull(firstSellerReview.getCreatedAt());
+
         assertNull(firstSellerReview.getSellerReplyText());
 
         SellerReview secondSellerReview = result.get(1);


### PR DESCRIPTION
Here we make it so that also in AdvancedSellerReivew the date of creation is written. I believe that it makes no sense to createAt field not for AdvancedSellerReview. Although it may be worth thinking about it.

Also a new method was added to FunPayUserUtil that parses the date of AdvancedSellerReview

Close #70 