### PR TITLE
Remove arguments from GetSellerReviews, GetUser commands in AuthorizedFunPayExecutor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 ext {
-    jsoupVersion = '1.18.1'
+    jsoupVersion = '1.18.3'
     okhttpVersion = '4.12.0'
     gsonVersion = '2.11.0'
-    lombokVersion = '1.18.34'
+    lombokVersion = '1.18.36'
 }
 
 allprojects {

--- a/core/src/main/java/ru/funpay4j/core/AuthorizedFunPayExecutor.java
+++ b/core/src/main/java/ru/funpay4j/core/AuthorizedFunPayExecutor.java
@@ -271,26 +271,24 @@ public class AuthorizedFunPayExecutor extends FunPayExecutor {
     /**
      * Execute to get user authorized
      *
-     * @param goldenKey golden key which will be used to authorize the user
      * @param command command that will be executed
      * @return user
      * @throws FunPayApiException if the other api-related exception
      * @throws UserNotFoundException if the user with id does not found
      */
-    public User execute(String goldenKey, GetUser command) throws FunPayApiException, UserNotFoundException {
+    public User execute(GetUser command) throws FunPayApiException, UserNotFoundException {
         return funPayParser.parseUser(goldenKey, command.getUserId());
     }
 
     /**
      * Execute to get seller reviews authorized
      *
-     * @param goldenKey golden key which will be used to authorize the user
      * @param command command that will be executed
      * @return seller reviews
      * @throws FunPayApiException if the other api-related exception
      * @throws UserNotFoundException if the user with id does not found/seller
      */
-    public List<SellerReview> execute(String goldenKey, GetSellerReviews command) throws FunPayApiException, UserNotFoundException {
+    public List<SellerReview> execute(GetSellerReviews command) throws FunPayApiException, UserNotFoundException {
         if (command.getStarsFilter() != null) {
             return funPayParser.parseSellerReviews(goldenKey, command.getUserId(), command.getPages(), command.getStarsFilter());
         } else {


### PR DESCRIPTION
Here we made a mistake, we just need to remove the goldenKey arguments and pass goldenKey from the global field AuthorizedFunPayExecutor itself to the method