### PR TITLE
Run builds on push and exclude draft pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,13 @@
 name: Build
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   build:


### PR DESCRIPTION
I added to build.yml to make the build happen at push and also turned it off if the pull request was turned into a draft